### PR TITLE
fix: incorrect requirement format

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,7 +1,4 @@
-roles:
-  - name: robertdebock-logrotate
-    src: git@github.com:robertdebock/ansible-role-logrotate.git
-    scm: git
-    version: 2.6.0
-collections:
-  - name: community.docker
+- name: robertdebock-logrotate
+  src: git@github.com:robertdebock/ansible-role-logrotate.git
+  scm: git
+  version: 2.6.0


### PR DESCRIPTION
meta/requirements.yml requires v1 format and can't handle collections (docker collection was not needed in role).